### PR TITLE
Fix installer with all windows language using sid

### DIFF
--- a/Install/Program.cs
+++ b/Install/Program.cs
@@ -134,7 +134,7 @@ namespace Install
 
                 td.Triggers.Add(trigger);
                 td.Actions.Add(new ExecAction(exePath, arguments, null));
-                ts.RootFolder.RegisterTaskDefinition(taskName, td, TaskCreation.CreateOrUpdate, "Authenticated Users", null, TaskLogonType.Group);
+                ts.RootFolder.RegisterTaskDefinition(taskName, td, TaskCreation.CreateOrUpdate, "S-1-5-11", null, TaskLogonType.Group);
             }
         }
 


### PR DESCRIPTION
I made a fix in the installer: I now use the SID instead of a hard-coded group name to ensure compatibility with other Windows languages, such as French in my case.

S-1-5-11 | Authenticated Users | A group that includes all users and computers with identities that have been authenticated. Authenticated Users doesn't include the Guest account even if that account has a password.This group includes authenticated security principals from any trusted domain, not only the current domain.
